### PR TITLE
Remove remote after job done. 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: "Dokku Deploy action"
+name: "Dokku Deploy action 2"
 author: "Ido Berkovich"
-description: "Deploy to a dokku instance using Github actions"
+description: "Deploy to a dokku instance using Github actions - removing remote after process allowing for multiple deploy targets in one go"
 branding:
   icon: "upload-cloud"
   color: "green"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,8 @@ ssh-keyscan $DOKKU_HOST >> ~/.ssh/known_hosts
 # Setup the git environment
 git_repo="$DOKKU_USER@$DOKKU_HOST:$DOKKU_APP_NAME"
 cd "$GITHUB_WORKSPACE"
+
+git remote rm deploy
 git remote add deploy "$git_repo"
 
 # Prepare to push to Dokku git repository
@@ -27,5 +29,4 @@ echo "GIT_COMMAND=$GIT_COMMAND"
 # Push to Dokku git repository
 GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" $GIT_COMMAND
 
-# remove remote
-git remote rm deploy
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,6 @@ ssh-keyscan $DOKKU_HOST >> ~/.ssh/known_hosts
 git_repo="$DOKKU_USER@$DOKKU_HOST:$DOKKU_APP_NAME"
 cd "$GITHUB_WORKSPACE"
 
-git remote rm deploy
 git remote add deploy "$git_repo"
 
 # Prepare to push to Dokku git repository
@@ -29,4 +28,4 @@ echo "GIT_COMMAND=$GIT_COMMAND"
 # Push to Dokku git repository
 GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" $GIT_COMMAND
 
-
+git remote rm deploy

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,3 +26,6 @@ echo "GIT_COMMAND=$GIT_COMMAND"
 
 # Push to Dokku git repository
 GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" $GIT_COMMAND
+
+# remove remote
+git remote rm deploy


### PR DESCRIPTION

To support 1 checkout and multiple deploys.
If you dont remove remote you get an error that remote "deploy" already exists.

