### PR TITLE
Add an option to specify a custom commit to be pushed

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 
 Port for ssh host. If not specified, `22` will be used.
 
+### commit
+
+Commit to deploy. If not specified, `$GITHUB_SHA` (current commit) will be used.
+
+
 ## Example
 
 Note: `actions/checkout` must preceed this action in order for the repository data to be exposed for the action.

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: "Custom port for ssh host"
     required: false
     default: "22"
+  commit:
+    description: "Commit to push to dokku. Defaults to $GITHUB_SHA"
+    required: false
+    default: ""
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -41,3 +45,4 @@ runs:
     - ${{ inputs.remote-branch }}
     - ${{ inputs.git-push-flags }}
     - ${{ inputs.ssh-port }}
+    - ${{ inputs.commit }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ DOKKU_APP_NAME=$4
 DOKKU_REMOTE_BRANCH=$5
 GIT_PUSH_FLAGS=$6
 SSH_PORT=$7
+COMMIT="${8:-$GITHUB_SHA}"
 
 # Setup the SSH environment
 mkdir -p ~/.ssh
@@ -20,7 +21,7 @@ cd "$GITHUB_WORKSPACE"
 git remote add deploy "$git_repo"
 
 # Prepare to push to Dokku git repository
-REMOTE_REF="$GITHUB_SHA:refs/heads/$DOKKU_REMOTE_BRANCH"
+REMOTE_REF="$COMMIT:refs/heads/$DOKKU_REMOTE_BRANCH"
 
 GIT_COMMAND="git push deploy $REMOTE_REF $GIT_PUSH_FLAGS"
 echo "GIT_COMMAND=$GIT_COMMAND"


### PR DESCRIPTION
This can be useful if you add additional commits in your Github Actions (e.g. a build phase) and want that to be deployed.